### PR TITLE
Mentor Create Page

### DIFF
--- a/mentor_scheduling_tool/src/App.jsx
+++ b/mentor_scheduling_tool/src/App.jsx
@@ -10,6 +10,7 @@ import Nav from "./components/Nav/Nav";
 //CSS
 import "./App.css";
 import MentorListPage from "./Pages/MentorListPage";
+import MentorCreationPage from "./Pages/MentorCreationPage";
 
 const HeaderLayout = () => {
   return (
@@ -28,6 +29,7 @@ const router = createBrowserRouter([
       { path: "/", element: <HomePage /> },
       { path: "/mentors", element: <MentorListPage /> },
       { path: "/mentors/:id", element: <MentorProfilePage /> },
+      { path: "/mentor-creation", element: <MentorCreationPage /> },
     ],
   },
 ]);

--- a/mentor_scheduling_tool/src/Components/Nav/Nav.jsx
+++ b/mentor_scheduling_tool/src/Components/Nav/Nav.jsx
@@ -1,13 +1,15 @@
 import { Link } from "react-router-dom";
 
 function Nav() {
-    return (
+  return (
     <nav>
-    <Link to="/">Home | </Link>
-    <Link to="/mentors">All Mentors | </Link>
-    <Link to="/mentors/1">Mentor 1 | </Link>
-    <Link to="/mentors/2">Mentor 2</Link>
-    </nav>);
+      <Link to="/">Home | </Link>
+      <Link to="/mentors">All Mentors | </Link>
+      <Link to="/mentors/1">Mentor 1 | </Link>
+      <Link to="/mentors/2">Mentor 2</Link>
+      <Link to="/mentor-creation">Create Mentor</Link>
+    </nav>
+  );
 }
 
 export default Nav;

--- a/mentor_scheduling_tool/src/Pages/MentorCreationPage.css
+++ b/mentor_scheduling_tool/src/Pages/MentorCreationPage.css
@@ -1,0 +1,77 @@
+#mentor_creation_form {
+  color: purple;
+}
+
+#mentor_info_banner {
+  display: flex;
+  justify-content: space-evenly;
+  /* display: flex;
+  justify-content: center; */
+  /* justify-content: space-around; */
+  /* align-content: space-around; */
+}
+
+.container_column {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+#container_radio {
+  display: flex;
+  flex-direction: row;
+}
+
+.container_label {
+  display: block;
+  /* padding-left: 50px; */
+  position: relative;
+  padding-left: 60px;
+}
+.container_label_input {
+  display: none;
+  /* background: rgb(96, 96, 99); */
+}
+.container_label_span {
+  border: 1px solid #ccc;
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  overflow: hidden;
+  line-height: 1;
+  text-align: center;
+  border-radius: 100%;
+  font-size: 35pt;
+  left: 0;
+  top: 50%;
+  margin-top: -7.5px;
+  background: rgb(96, 96, 99);
+  /* padding: 50px; */
+}
+.container_label_input:checked + span {
+  background: purple;
+  border-color: rgb(96, 96, 99);
+}
+
+/* #purple_background {
+  background-color: purple;
+
+  display: flex;
+}
+
+#white_background {
+  background-color: white;
+  border-radius: 40px;
+  padding: 100px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: column;
+  align-items: space-around;
+} */
+
+.purple_container {
+  background-color: rgb(222, 159, 222);
+  color: white;
+  min-height: 150px;
+}

--- a/mentor_scheduling_tool/src/Pages/MentorCreationPage.jsx
+++ b/mentor_scheduling_tool/src/Pages/MentorCreationPage.jsx
@@ -1,0 +1,149 @@
+//CSS
+import "./MentorCreationPage.css";
+
+function MentorCreationPage() {
+  return (
+    <div id="white_background">
+      <form id="mentor_creation_form">
+        <div id="personal_details">
+          {/* <input id="first_name"></input> */}
+          <label for="first_name">First Name</label>
+          <input type="text" name="first_name" id="first_name" required></input>
+          <label for="last_name">Last Name</label>
+          <input type="text" name="last_name" id="last_name" required></input>
+          <label for="email">Email</label>
+          <input type="email" name="email" id="email" required></input>
+        </div>
+        <label for="skills">Skills:</label>
+
+        <select name="skills" id="skills">
+          <option value="htmlcss">HTML and CSS</option>
+          <option value="python">Python</option>
+          <option value="django">Django</option>
+          <option value="react">AReactudi</option>
+        </select>
+
+        <label for="isactive"> Is active</label>
+        <input type="checkbox" name="isactive" value="isactive"></input>
+
+        <div id="mentor_info_banner" className="purple_container">
+          <div className="container_column">
+            {/* <label for="willtravel">
+              <p>Will Travel</p>
+            </label>
+            <input type="checkbox" name="willtravel" value="willtravel"></input> */}
+            <p>Will Travel</p>
+
+            <label className="container_label">
+              <input
+                className="container_label_input"
+                type="checkbox"
+                name="willtravel"
+                value="willtravel"
+              />
+              <span className="container_label_span">&#10003;</span>
+            </label>
+          </div>
+
+          <div className="container_column">
+            <p>Mentor Type</p>
+            <div id="container_radio">
+              {/* <input
+                type="radio"
+                id="mentortypej"
+                name="mentortype"
+                value="mentortypej"
+              ></input> */}
+              <label className="container_label">
+                <input
+                  className="container_label_input"
+                  type="radio"
+                  name="mentortype"
+                  value="mentortypej"
+                />
+                <span className="container_label_span">J</span>
+              </label>
+
+              <label className="container_label">
+                <input
+                  className="container_label_input"
+                  type="radio"
+                  name="mentortype"
+                  value="mentortypei"
+                />
+                <span className="container_label_span">I</span>
+              </label>
+
+              <label className="container_label">
+                <input
+                  className="container_label_input"
+                  type="radio"
+                  name="mentortype"
+                  value="mentortypel"
+                />
+                <span className="container_label_span">L</span>
+              </label>
+
+              {/* <label for="mentortypej">J</label>
+              <input
+                type="radio"
+                id="mentortypei"
+                name="mentortype"
+                value="mentortypei"
+              ></input>
+              <label for="mentortype">I</label>
+              <input
+                type="radio"
+                id="mentortypel"
+                name="mentortype"
+                value="mentortypel"
+              ></input>
+              <label for="mentortype">L</label> */}
+            </div>
+          </div>
+
+          <div className="container_column">
+            {/* <label for="alumni">
+              <p>Alumni</p>
+            </label>
+            <input type="checkbox" name="alumni" value="alumni"></input> */}
+            <p>Alumni</p>
+
+            <label className="container_label">
+              <input
+                className="container_label_input"
+                type="checkbox"
+                name="alumni"
+                value="alumni"
+              ></input>
+
+              <span className="container_label_span">&#10003;</span>
+            </label>
+          </div>
+        </div>
+        <label for="notes">Notes:</label>
+        <div id="mentor_notes_banner">
+          <textarea
+            className="purple_container"
+            id="notes"
+            name="notes"
+            rows="4"
+            cols="100"
+          ></textarea>
+        </div>
+        <label for="feedback">Feedback:</label>
+        <div id="mentor_feedback_banner">
+          <textarea
+            className="purple_container"
+            id="feedback"
+            name="feedback"
+            rows="4"
+            cols="100"
+          ></textarea>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default MentorCreationPage;


### PR DESCRIPTION
Added a BASIC template for the Mentor Create Page in my own files that I created:
1. MentorCreatePage.css
2. MentorCreatePage.jsx

I was thinking that if we like these as a group, we can copy code over into the EXISTING FILES app.css and app.jsx files for a 'General Template' and can then later edit the css to style every new page differently. For now, these files are going up to GIT and I can merge them into app.css and app.jsx after frontend discussion meeting if we think they are applicable enough.

Rough template view attached:
<img width="1440" alt="Screen Shot 2023-03-26 at 7 22 53 pm" src="https://user-images.githubusercontent.com/113986056/227773703-385ccf62-5ea2-4d30-a635-2aa3930baee6.png">

NEED TO DO:
1. Need to add more fields and more drop down options
2.  Need to edit styling and radio buttons
3. Need to incorporate accessibility 
4. Need to ensure we are using correct colours and fonts.