### PR TITLE
Media Queries and Formatting for all lists pages

### DIFF
--- a/src/Pages/MentorDetailPage.jsx
+++ b/src/Pages/MentorDetailPage.jsx
@@ -222,12 +222,12 @@ function MentorDetailPage() {
                           </td>
                           <td className="input">{mentorData.email}</td>
                         </tr>
-                        <tr>
+                        {/* <tr>
                           <td className="label">
                             <strong>Phone </strong>
                           </td>
                           <td className="input">{mentorData.phone}</td>
-                        </tr>
+                        </tr> */}
                         <tr>
                           <td className="label">
                             <strong>Location </strong>

--- a/src/Pages/MentorListPage.css
+++ b/src/Pages/MentorListPage.css
@@ -41,7 +41,7 @@
 .mentors-list-table>tr>td a:hover {
   /* border: 1px solid #8246af; */
   /* font-weight: 600; */
-  color: #8246af;
+  color: #F9A426;
 }
 
 
@@ -54,4 +54,26 @@ table.mentors-table{
   text-align: left;
   padding: 8px;
   border-bottom: 1px solid #ddd;
+}
+
+.mentor-table-container {
+  overflow-x: scroll;
+  max-width: 100%;
+  height: 500px; /* or any other fixed height */
+}
+
+#mentors-table {
+  width: 100%; /* make sure the table takes up the full width of the container */
+}
+
+/* remove the white-space property from the mentors-table */
+.mentors-list-table {
+  text-align: center;
+  font-size: 18px;
+  padding-left: 1rem;
+}
+
+.personal-information-container {
+  justify-content: space-around;
+
 }

--- a/src/Pages/MentorListPage.css
+++ b/src/Pages/MentorListPage.css
@@ -43,3 +43,15 @@
   /* font-weight: 600; */
   color: #8246af;
 }
+
+
+table.mentors-table{
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mentors-table th, .mentors-table td {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid #ddd;
+}

--- a/src/Pages/MentorListPage.jsx
+++ b/src/Pages/MentorListPage.jsx
@@ -33,7 +33,7 @@ function MentorListPage() {
                 <Link className="create-button" to={`/mentors/create`}>Create</Link>
             </div>
 
-            <table>
+            <table className="mentors-table">
                 <thead>
                     <tr>
                         <th>Type</th>

--- a/src/Pages/MentorListPage.jsx
+++ b/src/Pages/MentorListPage.jsx
@@ -33,6 +33,7 @@ function MentorListPage() {
                 <Link className="create-button" to={`/mentors/create`}>Create</Link>
             </div>
 
+            <div className="mentor-table-container">
             <table className="mentors-table">
                 <thead>
                     <tr>
@@ -76,6 +77,7 @@ function MentorListPage() {
                     ))}
                 </tbody>
             </table>
+            </div>
         </div>
 
 

--- a/src/Pages/ProgramListPage.css
+++ b/src/Pages/ProgramListPage.css
@@ -51,3 +51,14 @@ a.progress-link {
 /* font-weight: 600; */
 color: #8246af;
 }
+
+table.programs-table{
+    width: 100%;
+    border-collapse: collapse;
+  }
+  
+  .programs-table th, .programs-table td {
+    text-align: left;
+    padding: 8px;
+    border-bottom: 1px solid #ddd;
+  }

--- a/src/Pages/ProgramListPage.css
+++ b/src/Pages/ProgramListPage.css
@@ -49,7 +49,7 @@ a.progress-link {
 .programs-list-table>tr>td a:hover {
 /* border: 1px solid #8246af; */
 /* font-weight: 600; */
-color: #8246af;
+color: #F9A426;
 }
 
 table.programs-table{
@@ -62,3 +62,22 @@ table.programs-table{
     padding: 8px;
     border-bottom: 1px solid #ddd;
   }
+    
+/* Media query for small screens */
+@media screen and (max-width: 690px) {
+    .programs-table td {
+        display: block;
+        width: 100%;
+        border: none;
+        text-align: center;
+    }
+    .programs-table th{
+        display: none;
+    }
+    .programs-table tr {
+        border-bottom: 1px solid #ddd;
+    }
+    #program-name {
+    font-weight: bold;
+    }
+}

--- a/src/Pages/ProgramListPage.jsx
+++ b/src/Pages/ProgramListPage.jsx
@@ -60,7 +60,7 @@ function ProgramsListPage() {
                 <Link className="create-button" to={`/programs/create`}>Create</Link>
             </div>
 
-            <table>
+            <table className="programs-table">
                 <thead>
                     <tr>
                         <SortableTableHeader sortKey="program_name">Program</SortableTableHeader>

--- a/src/Pages/ProgramListPage.jsx
+++ b/src/Pages/ProgramListPage.jsx
@@ -75,7 +75,7 @@ function ProgramsListPage() {
                 <tbody className="programs-list-table">
                     {sortedProgramData?.map(program => (
                         <tr key={program.id}>
-                            <td><Link to={`/programs/${program.id}`} className="progress-link">{program.program_name}</Link></td>
+                            <td id="program-name"><Link to={`/programs/${program.id}`} className="progress-link">{program.program_name}</Link></td>
                             <td>{new Date(program.start_date).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: '2-digit' })}</td>
                             <td>{new Date(program.end_date).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: '2-digit' })}</td>
                             <td>{program.program_type}</td>

--- a/src/Pages/SessionListPage.css
+++ b/src/Pages/SessionListPage.css
@@ -72,16 +72,16 @@ table.sessions-table{
   .hide2{
     display: none !important;
   }
-  table#sessions-table td {
+  table.sessions-table td {
     display: block;
     width: 100%;
     border: none;
     text-align: center;
   }
-  table#sessions-table th{
+  table.sessions-table th{
     display: none;
   }
-  table#sessions-table tr {
+  table.sessions-table tr {
     border-bottom: 1px solid #ddd;
 }
 

--- a/src/Pages/SessionListPage.css
+++ b/src/Pages/SessionListPage.css
@@ -48,7 +48,7 @@ th {
 .sessions-list-table>tr>td a:hover {
   /* border: 1px solid #8246af; */
   /* font-weight: 600; */
-  color: #8246af;
+  color: #F9A426;
 }
 
 table.sessions-table{
@@ -60,4 +60,33 @@ table.sessions-table{
   text-align: left;
   padding: 8px;
   border-bottom: 1px solid #ddd;
+}
+
+.hide{
+  display: none;
+}
+
+/* Media query for small screens */
+@media screen and (max-width: 690px) {
+
+  .hide2{
+    display: none !important;
+  }
+  table#sessions-table td {
+    display: block;
+    width: 100%;
+    border: none;
+    text-align: center;
+  }
+  table#sessions-table th{
+    display: none;
+  }
+  table#sessions-table tr {
+    border-bottom: 1px solid #ddd;
+}
+
+  #session-name, #session-date, #program-name {
+    font-weight: bold;
+  }
+
 }

--- a/src/Pages/SessionListPage.css
+++ b/src/Pages/SessionListPage.css
@@ -51,3 +51,13 @@ th {
   color: #8246af;
 }
 
+table.sessions-table{
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.sessions-table th, .sessions-table td {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid #ddd;
+}

--- a/src/Pages/SessionListPage.jsx
+++ b/src/Pages/SessionListPage.jsx
@@ -62,7 +62,7 @@ function SessionListPage() {
             </div>
 
 
-            <table>
+            <table className="sessions-table">
                 <thead>
                     <tr>
                         {tableHeaders.map(header => (

--- a/src/Pages/SessionListPage.jsx
+++ b/src/Pages/SessionListPage.jsx
@@ -74,17 +74,19 @@ function SessionListPage() {
                 <tbody className="sessions-list-table">
                     {annotatedSessionData?.map(session => (
                         <tr key={session.id}>
-                            <td><Link to={`/sessions/${session.id}`}>{new Date(session.start_date).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: '2-digit' })}</Link></td>
-                            <td className="input">
+                            <td id="session-name" className="hide"><Link to={`/sessions/${session.id}`}>Session: {new Date(session.start_date).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: '2-digit' })} @ {new Date(session.start_date).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit', timeZone: 'UTC'})}</Link> </td>
+
+                            <td className="hide2"><Link to={`/sessions/${session.id}`}>{new Date(session.start_date).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: '2-digit' })}</Link></td>
+                            <td className="hide2">
                             {" "}
                             {new Date(session.start_date).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit', timeZone: 'UTC'})}
                             </td>
-                            <td><Link to={`/programs/${session.program}`}>{session.program_name}</Link></td>
+                            <td id="program-name"><Link to={`/programs/${session.program}`}>{session.program_name}</Link></td>
                             <td>{session.program_type}</td>
                             <td>{getModuleType[session.module_type]}</td>
                             <td>{session.city}</td>
                             <td>
-                                <ProgressBar 
+                                {/* <ProgressBar 
                                 completed={
                                     session.mentors_required > 0 
                                     ?  Math.ceil(
@@ -92,7 +94,8 @@ function SessionListPage() {
                                         )
                                     :0
                                 }
-                                ></ProgressBar>
+                                ></ProgressBar> */}
+                                {session.mentors_assigned}/{session.mentors_required}
                                 </td>
                             </tr>))}
                     </tbody>


### PR DESCRIPTION
- added lines between each entry for clarity... can be removed
- programs and sessions renders down vertically for smaller screens
- mentor lists has a vertical and horizontal scroll bar --> too much content to squish down into a media query